### PR TITLE
Determine cabal directory in a cross-platform manner

### DIFF
--- a/src/Distribution/Hackage/DB/Path.hs
+++ b/src/Distribution/Hackage/DB/Path.hs
@@ -11,7 +11,7 @@
 
 module Distribution.Hackage.DB.Path ( hackagePath ) where
 
-import System.Directory ( getHomeDirectory )
+import System.Directory ( getAppUserDataDirectory )
 import System.FilePath ( joinPath )
 
 -- | Determine the default path of the Hackage database, which typically
@@ -20,5 +20,5 @@ import System.FilePath ( joinPath )
 
 hackagePath :: IO FilePath
 hackagePath = do
-  homedir <- getHomeDirectory
-  return $ joinPath [homedir, ".cabal", "packages", "hackage.haskell.org", "00-index.tar"]
+  cabalDir <- getAppUserDataDirectory "cabal"
+  return $ joinPath [cabalDir, "packages", "hackage.haskell.org", "00-index.tar"]


### PR DESCRIPTION
Hi,

This patch fixes an issue I had when using hackage-db on Windows. It determines the location of the cabal directory in a way that is consistent with how [cabal does it][1], i.e. using `getAppUserDataDirectory "cabal"`.

On Unix-like platforms this will be `~/.cabal`, but on Windows it will be something like `<homedir>\AppData\Roaming\cabal`.

Thanks,
Ben

[1]: https://github.com/haskell/cabal/blob/9625cced119fcd195ab541cd6b7e6aabdb8412fc/cabal-install/Distribution/Client/Config.hs#L446