### PR TITLE
Parsed: don't filter out deprecated packages

### DIFF
--- a/src/Distribution/Hackage/DB/Parsed.hs
+++ b/src/Distribution/Hackage/DB/Parsed.hs
@@ -46,8 +46,7 @@ parseDB = Map.mapWithKey parsePackageData
 parsePackageData :: PackageName -> U.PackageData -> PackageData
 parsePackageData pn (U.PackageData pv vs') =
   mapException (\e -> HackageDBPackageName pn (e :: SomeException)) $
-    Map.mapWithKey (parseVersionData pn) $
-      Map.filterWithKey (\v _ -> v `withinRange` vr) vs'
+   Map.mapWithKey (parseVersionData pn) $ vs'
   where
     Dependency _ vr | BS.null pv = Dependency pn anyVersion
                     | otherwise  = parseText "preferred version range" (toString pv)


### PR DESCRIPTION
While deprecated packages have their place,
exposing hackage db is not the right place to
filter them, but it should rather expose information
to the user of hackage db api to decide what the best
action is given the information.

cc @peti