### PR TITLE
Remove sudo:false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
 language: c
-sudo: false
 
 git:
   submodules: false  # whether to recursively clone submodules


### PR DESCRIPTION
Container-based Travis envs get phased out soon. See some more details in https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures and https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration