### PR TITLE
hackage-db.cabal: increase lower bound on Cabal to 3.4

### DIFF
--- a/hackage-db.cabal
+++ b/hackage-db.cabal
@@ -36,7 +36,7 @@ library
   other-modules:    Paths_hackage_db
   hs-source-dirs:   src
   build-depends:    base        >= 4.9 && < 5
-                  , Cabal       > 3
+                  , Cabal       >= 3.4
                   , aeson
                   , bytestring
                   , containers


### PR DESCRIPTION
hackage-db 2.1.1 doesn't work properly with Cabal 3.2.*,
so it seems we need to require at least Cabal 3.4:
https://github.com/NixOS/cabal2nix/issues/501

Uploading a revised cabal file to hackage would be nice, so stackage
hopefully reverts to hackage-db 2.1.0 (if that even works). Not sure
if hackage-db 2.1.0 needs an upper bound on Cabal (< 3.4).